### PR TITLE
add BOJ2468.java, BOJ14888.java

### DIFF
--- a/yechan2468/BOJ14888.java
+++ b/yechan2468/BOJ14888.java
@@ -1,0 +1,62 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ14888 {
+    static int n;
+    static int max = Integer.MIN_VALUE;
+    static int min = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(reader.readLine());
+        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+        int[] numbers = new int[n];
+        for (int i = 0; i < n; i++) {
+            numbers[i] = Integer.parseInt(tokenizer.nextToken());
+        }
+        tokenizer = new StringTokenizer(reader.readLine());
+        int[] operators = new int[4];
+        for (int i = 0; i < 4; i++) {
+            operators[i] = Integer.parseInt(tokenizer.nextToken());
+        }
+
+        dfs(numbers[0], 1, numbers, operators);
+
+        System.out.println(max);
+        System.out.println(min);
+    }
+
+    static void dfs(int prevValue, int index, int[] numbers, int[] operators) {
+        if (index == n) {
+            max = Math.max(max, prevValue);
+            min = Math.min(min, prevValue);
+            return;
+        }
+        for (int i = 0; i < 4; i++) {
+            if (operators[i] <= 0) {
+                continue;
+            }
+            int currValue = 0;
+            switch (i) {
+                case 0:
+                    currValue = prevValue + numbers[index];
+                    break;
+                case 1:
+                    currValue = prevValue - numbers[index];
+                    break;
+                case 2:
+                    currValue = prevValue * numbers[index];
+                    break;
+                case 3:
+                    currValue = prevValue / numbers[index];
+            }
+
+            int[] nextOperators = operators.clone();
+            nextOperators[i]--;
+
+            dfs(currValue, index+1, numbers, nextOperators);
+        }
+    }
+}

--- a/yechan2468/BOJ2468.java
+++ b/yechan2468/BOJ2468.java
@@ -1,0 +1,77 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ2468 {
+    static int n, answer;
+    static int[][] heights;
+    static int[] dx = new int[]{0, 1, 0, -1};
+    static int[] dy = new int[]{-1, 0, 1, 0};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(reader.readLine());
+        heights = new int[n + 2][n + 2];
+        for (int i = 1; i <= n; i++) {
+            StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+            for (int j = 1; j <= n; j++) {
+                heights[i][j] = Integer.parseInt(tokenizer.nextToken());
+            }
+        }
+
+        for (int level = 0; level < 100; level++) {
+            int count = 0;
+            boolean[][] isSunk = new boolean[n+2][n+2];
+            for (int i = 0; i < n+2; i++) {
+                isSunk[i][0] = isSunk[i][n+1] = isSunk[0][i] = isSunk[n+1][i] = true;
+            }
+            for (int i = 1; i <= n; i++) {
+                for (int j = 1; j <= n; j++) {
+                    if (heights[i][j] <= level) {
+                        isSunk[i][j] = true;
+                    }
+                }
+            }
+
+            for (int i = 1; i <= n; i++) {
+                for (int j = 1; j <= n; j++) {
+                    if (!isSunk[i][j] && heights[i][j] > level) {
+                        bfs(new Pair(i, j), level, isSunk);
+                        count++;
+                    }
+                }
+            }
+
+            answer = Math.max(answer, count);
+        }
+
+        System.out.println(answer);
+    }
+
+    static void bfs(Pair curr, int level, boolean[][] visited) {
+        Queue<Pair> queue = new LinkedList<>();
+        queue.offer(curr);
+        visited[curr.y][curr.x] = true;
+        while (!queue.isEmpty()) {
+            Pair next = queue.poll();
+            for (int i = 0; i < 4; i++) {
+                int ny = next.y + dy[i];
+                int nx = next.x + dx[i];
+                if (visited[ny][nx] || heights[ny][nx] <= level) continue;
+                bfs(new Pair(ny, nx), level, visited);
+            }
+        }
+    }
+
+    static class Pair {
+        int y, x;
+
+        public Pair(int y, int x) {
+            this.y = y;
+            this.x = x;
+        }
+    }
+}


### PR DESCRIPTION
## 백준 2468 안전영역

[https://www.acmicpc.net/problem/2468](https://www.acmicpc.net/problem/2468)

BFS를 이용해 풀이했습니다.
처음에 단순 BFS의 반복만으로는 제시간에 풀이를 못할 것으로 잘못 판단해 다른 방법으로 고민을 꽤 긴 시간 했지만, 생각보다 쉬웠습니다

고민했던 내용:

비 수위가 더 높아지면, 안전 구역의 개수는
- 늘어난다: 원래 존재했던 안전구역이 분리
- 줄어든다: 원래 존재했던 안전구역이 침몰
위 두 경우의 수이다.

각 칸의 번호를 지정하고, 수위가 높아지는 문제에서 낮아지는 문제로 바꾼다면 이를 union find를 이용해 안전구역이 서로 합쳐지는 문제로 해석할 수 있을 것이다.
안전구역이 서로 합쳐질 때, 서로 다른 k개의 안전구역이 합쳐진다면 총 안전구역의 개수는 k-1개 줄어든다.

실제로 가능한 풀이이기는 하지만, 결론적으로 다 갈아엎고 쉬운 BFS로 구현했습니다.

소요 시간: 약 2시간


## 백준 14888 연산자 끼워넣기

[https://www.acmicpc.net/problem/14888](https://www.acmicpc.net/problem/14888)

모든 연산자 조합을 시도하여 답을 얻어냈습니다.

소요 시간: 약 30분

