### PR TITLE
BOJ2470, BOJ2512

### DIFF
--- a/yechan2468/BOJ2470.java
+++ b/yechan2468/BOJ2470.java
@@ -1,0 +1,39 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ2470 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(reader.readLine());
+        long[] numbers = new long[n];
+        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+        for (int i = 0; i < n; i++) {
+            numbers[i] = Long.parseLong(tokenizer.nextToken());
+        }
+
+        Arrays.sort(numbers);
+
+        int pointer0 = 0, pointer1 = n-1;
+        long answer0 = 0, answer1 = 0;
+        long min = Long.MAX_VALUE;
+        while (pointer0 < pointer1) {
+            long curr = numbers[pointer0] + numbers[pointer1];
+            if (Math.abs(curr) < min) {
+                min = Math.abs(curr);
+                answer0 = numbers[pointer0];
+                answer1 = numbers[pointer1];
+            }
+
+            if (curr < 0) {
+                pointer0++;
+            } else {
+                pointer1--;
+            }
+        }
+
+        System.out.println(answer0 + " " + answer1);
+    }
+}

--- a/yechan2468/BOJ2512.java
+++ b/yechan2468/BOJ2512.java
@@ -1,0 +1,60 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ2512 {
+    static int n;
+    static int[] numbers;
+    static long maxBudget;
+
+    public static void main(String[] args) throws IOException {
+        getInput();
+
+        Arrays.sort(numbers);
+
+        int sum = 0;
+        long minDiff = Long.MAX_VALUE;
+        for (int i = 1; i < n+1; i++) {
+            int unit = n - (i-1);
+            sum += (numbers[i] - numbers[i-1]) * unit;
+            long newDiff = maxBudget - sum;
+
+            if (newDiff == 0) {
+                System.out.println(numbers[i]);
+                return;
+            }
+
+            if (newDiff > 0 && newDiff <= minDiff) {
+                minDiff = newDiff;
+            } else {
+                int prevSum = sum - (numbers[i] - numbers[i-1]) * unit;
+                long answer = numbers[i-1] + (maxBudget - prevSum) / unit;
+                System.out.println(answer);
+                return;
+            }
+        }
+    }
+
+    private static void getInput() throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(reader.readLine());
+        numbers = new int[n+1];
+        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+        int numbersSum = 0;
+        int maxNumber = 0;
+        for (int i = 1; i < n+1; i++) {
+            int number = Integer.parseInt(tokenizer.nextToken());
+            numbersSum += number;
+            maxNumber = Math.max(maxNumber, number);
+            numbers[i] = number;
+        }
+        maxBudget = Long.parseLong(reader.readLine());
+
+        if (numbersSum <= maxBudget) {
+            System.out.println(maxNumber);
+            System.exit(0);
+        }
+    }
+}


### PR DESCRIPTION
## BOJ 2470 두 용액

[https://www.acmicpc.net/problem/2470](https://www.acmicpc.net/problem/2470)

Gold V

투 포인터 기법으로 풀었습니다.

소요 시간: 23분


## BOJ 2512 예산

[https://www.acmicpc.net/problem/2512](https://www.acmicpc.net/problem/2512)

Silver II

정렬 ($$O(n log n)$$) 후 직접 누적값을 더해주는($$O(n)$$) 방법으로 하였으며, 특별한 알고리즘 기법 없이 구현했습니다.

소요 시간: 1시간 1분

---

두 문제 모두 나중에 살펴보니 binary search로 풀 수 있는 문제였다는 것을 알게 되었습니다. 생각의 폭을 넓힐 필요성이 있다는 것을 다시 한 번 알게 되었습니다

