### PR TITLE
BOJ9527

### DIFF
--- a/yechan2468/BOJ9527.java
+++ b/yechan2468/BOJ9527.java
@@ -7,7 +7,7 @@ import java.util.StringTokenizer;
 
 public class BOJ9527 {
     static long a, b;
-    static long[] exps, sums;
+    static long[] sums;
     static Map<Long, Long> memo;
 
     public static void main(String[] args) throws IOException {
@@ -15,16 +15,14 @@ public class BOJ9527 {
 
         sums[0] = 1;
         for (int i = 1; i < 60; i++) {
-            sums[i] = sums[i - 1] * 2 + exps[i];
+            sums[i] = sums[i - 1] * 2 + (1L << i);
         }
 
         System.out.println(get(b) - get(a - 1));
     }
 
     private static long get(long x) {
-        if (x <= 2) return x;
-        else if (x == 3) return 4;
-        else if (memo.containsKey(x)) return memo.get(x);
+        if (memo.containsKey(x)) return memo.get(x);
 
         long highest = Long.highestOneBit(x);
         int k = log2(highest);
@@ -49,13 +47,10 @@ public class BOJ9527 {
         StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
         a = Long.parseLong(tokenizer.nextToken());
         b = Long.parseLong(tokenizer.nextToken());
-        exps = new long[60];
-        long curr = 1L;
-        for (int i = 0; i < exps.length; i++) {
-            exps[i] = curr;
-            curr <<= 1;
-        }
         sums = new long[60];
         memo = new HashMap<>();
+        for (long i = 0; i < 3; i++) {
+            memo.put(i, i);
+        }
     }
 }


### PR DESCRIPTION
## 백준 9527 1의 개수 세기

난이도: 골드 2

이진수의 규칙성을 이용해 DP로 풀었습니다..

소요 시간: 약 4시간