### PR TITLE
BOJ2042

### DIFF
--- a/yechan2468/BOJ2042.java
+++ b/yechan2468/BOJ2042.java
@@ -1,0 +1,59 @@
+import java.io.*;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.TreeMap;
+
+public class BOJ2042 {
+    static final String UPDATE = "1";
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+
+        int n = Integer.parseInt(tokenizer.nextToken());
+        long[] numbers = new long[n];
+        for (int i = 0; i < n; i++) {
+            numbers[i] = Long.parseLong(reader.readLine());
+        }
+        long[] sums = new long[n];
+        sums[0] = numbers[0];
+        for (int i = 1; i < n; i++) {
+            sums[i] = sums[i-1] + numbers[i];
+        }
+
+        int numUpdate = Integer.parseInt(tokenizer.nextToken());
+        TreeMap<Integer, Long> updates = new TreeMap<>();
+        int numQuery = Integer.parseInt(tokenizer.nextToken());
+
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        for (int i = 0; i < numUpdate + numQuery; i++) {
+            tokenizer = new StringTokenizer(reader.readLine());
+            String operation = tokenizer.nextToken();
+
+            if (operation.equals(UPDATE)) {
+                int targetIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                long newNumber = Long.parseLong(tokenizer.nextToken());
+                updates.put(targetIndex, newNumber);
+            } else {
+                int startIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                int endIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                long answer = sums[endIndex] - sums[startIndex] + numbers[startIndex];
+
+                Set<Map.Entry<Integer, Long>> entries = updates.subMap(startIndex, true, endIndex, true).entrySet();
+                for (Map.Entry<Integer, Long> entry : entries) {
+                    Integer updateIndex = entry.getKey();
+                    if (startIndex <= updateIndex && updateIndex <= endIndex) {
+                        answer -= numbers[updateIndex];
+                        answer += entry.getValue();
+                    }
+                }
+
+                writer.write(answer + "\n");
+            }
+        }
+
+        writer.flush();
+    }
+}

--- a/yechan2468/BOJ2042_0.java
+++ b/yechan2468/BOJ2042_0.java
@@ -1,0 +1,54 @@
+import java.io.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class BOJ2042_0 {
+    static final String UPDATE = "1";
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+
+        int n = Integer.parseInt(tokenizer.nextToken());
+        long[] numbers = new long[n];
+        for (int i = 0; i < n; i++) {
+            numbers[i] = Long.parseLong(reader.readLine());
+        }
+        long[] sums = new long[n];
+        sums[0] = numbers[0];
+        for (int i = 1; i < n; i++) {
+            sums[i] = sums[i-1] + numbers[i];
+        }
+
+        int numUpdate = Integer.parseInt(tokenizer.nextToken());
+        Map<Integer, Long> updates = new HashMap<>();
+        int numQuery = Integer.parseInt(tokenizer.nextToken());
+
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        for (int i = 0; i < numUpdate + numQuery; i++) {
+            tokenizer = new StringTokenizer(reader.readLine());
+            String operation = tokenizer.nextToken();
+
+            if (operation.equals(UPDATE)) {
+                int targetIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                long newNumber = Long.parseLong(tokenizer.nextToken());
+                updates.put(targetIndex, newNumber);
+            } else {
+                int startIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                int endIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                long answer = sums[endIndex] - sums[startIndex] + numbers[startIndex];
+                for (int updateIndex: updates.keySet()) {
+                    if (startIndex <= updateIndex && updateIndex <= endIndex) {
+                        answer -= numbers[updateIndex];
+                        answer += updates.get(updateIndex);
+                    }
+                }
+                writer.write(answer + "\n");
+            }
+        }
+
+        writer.flush();
+    }
+}

--- a/yechan2468/BOJ2042_1.java
+++ b/yechan2468/BOJ2042_1.java
@@ -1,0 +1,74 @@
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BOJ2042_1 {
+    static final String UPDATE = "1";
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+
+        int n = Integer.parseInt(tokenizer.nextToken());
+        long[] numbers = new long[n];
+        FenwickTree tree = new FenwickTree(n);
+        for (int i = 0; i < n; i++) {
+            numbers[i] = Long.parseLong(reader.readLine());
+            tree.update(i, numbers[i]);
+        }
+
+        int numUpdate = Integer.parseInt(tokenizer.nextToken());
+        int numQuery = Integer.parseInt(tokenizer.nextToken());
+
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        for (int i = 0; i < numUpdate + numQuery; i++) {
+            tokenizer = new StringTokenizer(reader.readLine());
+            String operation = tokenizer.nextToken();
+
+            if (operation.equals(UPDATE)) {
+                int targetIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                long newNumber = Long.parseLong(tokenizer.nextToken());
+                tree.update(targetIndex, newNumber - numbers[targetIndex]);
+                numbers[targetIndex] = newNumber;
+            } else {
+                int startIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                int endIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                long answer = tree.query(endIndex) - tree.query(startIndex) + numbers[startIndex];
+
+                writer.write(answer + "\n");
+            }
+        }
+
+        writer.flush();
+    }
+
+    static private class FenwickTree {
+        private final long[] tree;
+        private final int size;
+
+        public FenwickTree(int n) {
+            tree = new long[n + 1];
+            size = n;
+        }
+
+        public void update(int index, long delta) {
+            index++;
+            while (index <= size) {
+                tree[index] += delta;
+                index += (index & -index);
+            }
+        }
+
+        public long query(int index) {
+            index++;
+            long answer = 0;
+            while (index > 0) {
+                answer += tree[index];
+                index -= (index & -index);
+            }
+
+            return answer;
+        }
+    }
+
+}

--- a/yechan2468/BOJ2042_2.java
+++ b/yechan2468/BOJ2042_2.java
@@ -1,0 +1,94 @@
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BOJ2042_2 {
+    static int n;
+    static final String UPDATE = "1";
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+
+        n = Integer.parseInt(tokenizer.nextToken());
+        long[] numbers = new long[n];
+        for (int i = 0; i < n; i++) {
+            numbers[i] = Long.parseLong(reader.readLine());
+        }
+        SegmentTree tree = new SegmentTree(numbers);
+
+        int numUpdate = Integer.parseInt(tokenizer.nextToken());
+        int numQuery = Integer.parseInt(tokenizer.nextToken());
+
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        for (int i = 0; i < numUpdate + numQuery; i++) {
+            tokenizer = new StringTokenizer(reader.readLine());
+            String operation = tokenizer.nextToken();
+
+            if (operation.equals(UPDATE)) {
+                int targetIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                long newNumber = Long.parseLong(tokenizer.nextToken());
+                tree.update(targetIndex, newNumber - numbers[targetIndex]);
+                numbers[targetIndex] = newNumber;
+
+            } else {
+                int startIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                int endIndex = Integer.parseInt(tokenizer.nextToken()) - 1;
+                long answer = tree.query(startIndex, endIndex);
+
+                writer.write(answer + "\n");
+            }
+        }
+
+        writer.flush();
+    }
+
+    static private class SegmentTree {
+        private final long[] tree;
+        private int n = 1;
+
+        public SegmentTree(long[] input) {
+            while (n < input.length) {
+                n <<= 1;
+            }
+            tree = new long[2 * n];
+            long[] arr = new long[n];
+            System.arraycopy(input, 0, arr, 0, input.length);
+            build(1, 0, arr.length - 1, arr);
+        }
+
+        private void build(int curr, int l, int r, long[] arr) {
+            if (l == r) {
+                tree[curr] = arr[l];
+                return;
+            }
+
+            int mid = (l + r) / 2;
+            build(curr * 2, l, mid, arr);
+            build(curr * 2 + 1, mid + 1, r, arr);
+            tree[curr] = tree[curr * 2] + tree[curr * 2 + 1];
+        }
+
+        public void update(int index, long delta) {
+            index += n;
+            tree[index] += delta;
+            for (index /= 2; index >= 1; index /= 2) {
+                tree[index] = tree[2 * index] + tree[2 * index + 1];
+            }
+        }
+
+        public long query(int start, int end) {
+            start += n; end += n;
+            long result = 0L;
+
+            while (start <= end) {
+                if (start % 2 == 1) result += tree[start++];
+                if (end % 2 == 0) result += tree[end--];
+                start /= 2; end /= 2;
+            }
+
+            return result;
+        }
+    }
+
+}


### PR DESCRIPTION
## 백준 2042 구간 합 구하기

난이도: 골드 1

다양한 방법으로 문제를 풀어보았습니다

<img width="703" height="181" alt="image" src="https://github.com/user-attachments/assets/f91c48a9-8143-4449-8b0a-23a9d01de0cf" />

1. Segment Tree　...　 $$O(N + (M + K) \log N)$$
2. Fenwick Tree　...　 $$O(N \log N + (M + K) \log N)$$
3. Range Sum + TreeMap (RB-tree based)　...　 $$O(N + M \log M + K(\log M + U))$$
4. Range Sum + HashMap　...　 $$O(N + M + KM) $$

(N: 수의 개수, M: 수의 변경이 일어난 횟수, K: 구간의 합을 구하는 횟수, U: 쿼리 구간 내 업데이트 수)
(N <= 100만, K <= 1만, M <= 1만이며 $$(\log_2 1000000) \approx 20$$)

Range Sum을 사용한 경우, 구간 합 배열을 만든 뒤, 구간의 합을 구할 때마다 업데이트 여부를 확인하므로 (HashMap) $$O(N + M + KM) $$ 또는 (TreeMap) $$O(N + M \log M + K(\log M + U))$$의 시간이 걸리지만,
Fenwick Tree 또는 Segment Tree를 사용한 경우, 업데이트와 쿼리에 각각 모두 $$\log N$$ 만큼의 시간이 걸리므로 (Fenwick Tree) $$O(N \log N + (M + K) \log N)$$, (Segment Tree) $$O(N + (M + K) \log N)$$ 의 시간이 걸려 1/8 ~ 1/9배 정도의 시간으로 더 효율적으로 처리하는 것을 확인할 수 있었읍니다


소요 시간: 약 40분 (첫 번째 정답까지)
