### PR TITLE
BOJ1520

### DIFF
--- a/yechan2468/BOJ1520.java
+++ b/yechan2468/BOJ1520.java
@@ -4,50 +4,22 @@ import java.io.InputStreamReader;
 import java.util.*;
 
 public class BOJ1520 {
+    private static int numRow, numColumn;
+    private static int[][] heights, indegrees, memo;
+    private static List<List<List<Point>>> graph;
     private static final int[] dy = {-1, 0, 0, 1}, dx = {0, -1, 1, 0};
 
     public static void main(String[] args) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
-        int numRow = Integer.parseInt(tokenizer.nextToken());
-        int numColumn = Integer.parseInt(tokenizer.nextToken());
-        int[][] heights = new int[numRow][numColumn];
-        for (int row = 0; row < numRow; row++) {
-            tokenizer = new StringTokenizer(reader.readLine());
-            for (int col = 0; col < numColumn; col++) {
-                heights[row][col] = Integer.parseInt(tokenizer.nextToken());
-            }
-        }
-        List<List<List<Point>>> graph = new ArrayList<>();
-        for (int row = 0; row < numRow; row++) {
-            graph.add(new ArrayList<>());
-            for (int col = 0; col < numColumn; col++) {
-                graph.get(row).add(new ArrayList<>());
-            }
-        }
-        int[][] indegrees = new int[numRow][numColumn];
-        for (int row = 0; row < numRow; row++) {
-            for (int col = 0; col < numColumn; col++) {
-                for (int dir = 0; dir < 4; dir++) {
-                    int nRow = row + dy[dir], nCol = col + dx[dir];
-                    if (nRow < 0 || nRow >= numRow || nCol < 0 || nCol >= numColumn) continue;
-                    if (heights[nRow][nCol] >= heights[row][col]) continue;
-                    graph.get(row).get(col).add(new Point(nRow, nCol));
-                    indegrees[nRow][nCol]++;
-                }
-            }
-        }
-        int[][] memo = new int[numRow][numColumn];
-        memo[0][0] = 1;
+        initialize();
 
-        Queue<Point> queue = new LinkedList<>();
-        for (int row = 0; row < numRow; row++) {
-            for (int col = 0; col < numColumn; col++) {
-                if (indegrees[row][col] == 0) {
-                    queue.offer(new Point(row, col));
-                }
-            }
-        }
+        topologicalSort();
+
+        int answer = memo[numRow - 1][numColumn - 1];
+        System.out.println(answer);
+    }
+
+    private static void topologicalSort() {
+        Queue<Point> queue = initQueue();
 
         while (!queue.isEmpty()) {
             Point curr = queue.poll();
@@ -60,8 +32,58 @@ public class BOJ1520 {
                 }
             }
         }
+    }
 
-        System.out.println(memo[numRow - 1][numColumn - 1]);
+    private static Queue<Point> initQueue() {
+        Queue<Point> queue = new LinkedList<>();
+        for (int row = 0; row < numRow; row++) {
+            for (int col = 0; col < numColumn; col++) {
+                if (indegrees[row][col] == 0) {
+                    queue.offer(new Point(row, col));
+                }
+            }
+        }
+        return queue;
+    }
+
+    private static void initialize() throws IOException {
+        readInput();
+
+        graph = new ArrayList<>();
+        for (int row = 0; row < numRow; row++) {
+            graph.add(new ArrayList<>());
+            for (int col = 0; col < numColumn; col++) {
+                graph.get(row).add(new ArrayList<>());
+            }
+        }
+        indegrees = new int[numRow][numColumn];
+        for (int row = 0; row < numRow; row++) {
+            for (int col = 0; col < numColumn; col++) {
+                for (int dir = 0; dir < 4; dir++) {
+                    int nRow = row + dy[dir], nCol = col + dx[dir];
+                    if (nRow < 0 || nRow >= numRow || nCol < 0 || nCol >= numColumn) continue;
+                    if (heights[nRow][nCol] >= heights[row][col]) continue;
+                    graph.get(row).get(col).add(new Point(nRow, nCol));
+                    indegrees[nRow][nCol]++;
+                }
+            }
+        }
+        memo = new int[numRow][numColumn];
+        memo[0][0] = 1;
+    }
+
+    private static void readInput() throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+        numRow = Integer.parseInt(tokenizer.nextToken());
+        numColumn = Integer.parseInt(tokenizer.nextToken());
+        heights = new int[numRow][numColumn];
+        for (int row = 0; row < numRow; row++) {
+            tokenizer = new StringTokenizer(reader.readLine());
+            for (int col = 0; col < numColumn; col++) {
+                heights[row][col] = Integer.parseInt(tokenizer.nextToken());
+            }
+        }
     }
 
     private static class Point {

--- a/yechan2468/BOJ1520.java
+++ b/yechan2468/BOJ1520.java
@@ -1,0 +1,75 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class BOJ1520 {
+    private static final int[] dy = {-1, 0, 0, 1}, dx = {0, -1, 1, 0};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+        int numRow = Integer.parseInt(tokenizer.nextToken());
+        int numColumn = Integer.parseInt(tokenizer.nextToken());
+        int[][] heights = new int[numRow][numColumn];
+        for (int row = 0; row < numRow; row++) {
+            tokenizer = new StringTokenizer(reader.readLine());
+            for (int col = 0; col < numColumn; col++) {
+                heights[row][col] = Integer.parseInt(tokenizer.nextToken());
+            }
+        }
+        List<List<List<Point>>> graph = new ArrayList<>();
+        for (int row = 0; row < numRow; row++) {
+            graph.add(new ArrayList<>());
+            for (int col = 0; col < numColumn; col++) {
+                graph.get(row).add(new ArrayList<>());
+            }
+        }
+        int[][] indegrees = new int[numRow][numColumn];
+        for (int row = 0; row < numRow; row++) {
+            for (int col = 0; col < numColumn; col++) {
+                for (int dir = 0; dir < 4; dir++) {
+                    int nRow = row + dy[dir], nCol = col + dx[dir];
+                    if (nRow < 0 || nRow >= numRow || nCol < 0 || nCol >= numColumn) continue;
+                    if (heights[nRow][nCol] >= heights[row][col]) continue;
+                    graph.get(row).get(col).add(new Point(nRow, nCol));
+                    indegrees[nRow][nCol]++;
+                }
+            }
+        }
+        int[][] memo = new int[numRow][numColumn];
+        memo[0][0] = 1;
+
+        Queue<Point> queue = new LinkedList<>();
+        for (int row = 0; row < numRow; row++) {
+            for (int col = 0; col < numColumn; col++) {
+                if (indegrees[row][col] == 0) {
+                    queue.offer(new Point(row, col));
+                }
+            }
+        }
+
+        while (!queue.isEmpty()) {
+            Point curr = queue.poll();
+
+            for (Point next : graph.get(curr.row).get(curr.col)) {
+                indegrees[next.row][next.col]--;
+                memo[next.row][next.col] += memo[curr.row][curr.col];
+                if (indegrees[next.row][next.col] == 0) {
+                    queue.offer(next);
+                }
+            }
+        }
+
+        System.out.println(memo[numRow - 1][numColumn - 1]);
+    }
+
+    private static class Point {
+        int row, col;
+
+        public Point(int row, int col) {
+            this.row = row;
+            this.col = col;
+        }
+    }
+}

--- a/yechan2468/BOJ1520.java
+++ b/yechan2468/BOJ1520.java
@@ -7,7 +7,6 @@ public class BOJ1520 {
     private static int numRow, numColumn;
     private static int[][] heights, indegrees, memo;
     private static List<List<List<Point>>> graph;
-    private static final int[] dy = {-1, 0, 0, 1}, dx = {0, -1, 1, 0};
 
     public static void main(String[] args) throws IOException {
         initialize();
@@ -25,8 +24,9 @@ public class BOJ1520 {
             Point curr = queue.poll();
 
             for (Point next : graph.get(curr.row).get(curr.col)) {
-                indegrees[next.row][next.col]--;
                 memo[next.row][next.col] += memo[curr.row][curr.col];
+
+                indegrees[next.row][next.col]--;
                 if (indegrees[next.row][next.col] == 0) {
                     queue.offer(next);
                 }
@@ -43,33 +43,15 @@ public class BOJ1520 {
                 }
             }
         }
+
         return queue;
     }
 
     private static void initialize() throws IOException {
         readInput();
-
-        graph = new ArrayList<>();
-        for (int row = 0; row < numRow; row++) {
-            graph.add(new ArrayList<>());
-            for (int col = 0; col < numColumn; col++) {
-                graph.get(row).add(new ArrayList<>());
-            }
-        }
-        indegrees = new int[numRow][numColumn];
-        for (int row = 0; row < numRow; row++) {
-            for (int col = 0; col < numColumn; col++) {
-                for (int dir = 0; dir < 4; dir++) {
-                    int nRow = row + dy[dir], nCol = col + dx[dir];
-                    if (nRow < 0 || nRow >= numRow || nCol < 0 || nCol >= numColumn) continue;
-                    if (heights[nRow][nCol] >= heights[row][col]) continue;
-                    graph.get(row).get(col).add(new Point(nRow, nCol));
-                    indegrees[nRow][nCol]++;
-                }
-            }
-        }
-        memo = new int[numRow][numColumn];
-        memo[0][0] = 1;
+        graph = initGraph();
+        indegrees = initIndegrees();
+        memo = initMemo();
     }
 
     private static void readInput() throws IOException {
@@ -84,6 +66,44 @@ public class BOJ1520 {
                 heights[row][col] = Integer.parseInt(tokenizer.nextToken());
             }
         }
+    }
+
+    private static List<List<List<Point>>> initGraph() {
+        List<List<List<Point>>> graph = new ArrayList<>();
+        for (int row = 0; row < numRow; row++) {
+            graph.add(new ArrayList<>());
+            for (int col = 0; col < numColumn; col++) {
+                graph.get(row).add(new ArrayList<>());
+            }
+        }
+
+        return graph;
+    }
+
+    private static int[][] initIndegrees() {
+        int[] dy = {-1, 0, 0, 1}, dx = {0, -1, 1, 0};
+
+        int[][] indegrees = new int[numRow][numColumn];
+        for (int row = 0; row < numRow; row++) {
+            for (int col = 0; col < numColumn; col++) {
+                for (int dir = 0; dir < 4; dir++) {
+                    int nRow = row + dy[dir], nCol = col + dx[dir];
+                    if (nRow < 0 || nRow >= numRow || nCol < 0 || nCol >= numColumn) continue;
+                    if (heights[nRow][nCol] >= heights[row][col]) continue;
+                    graph.get(row).get(col).add(new Point(nRow, nCol));
+                    indegrees[nRow][nCol]++;
+                }
+            }
+        }
+
+        return indegrees;
+    }
+
+    private static int[][] initMemo() {
+        int[][] memo = new int[numRow][numColumn];
+        memo[0][0] = 1;
+
+        return memo;
     }
 
     private static class Point {


### PR DESCRIPTION
## 백준 1520 내리막길

[https://www.acmicpc.net/problem/1520](https://www.acmicpc.net/problem/1520)

난이도: 골드3
소요 시간: 55분

### 풀이 아이디어

초기 칸(0, 0)을 경우의 수 1로 둔 뒤, 모든 칸에 대하여 본인 칸을 제외한 사방 중 본인 칸보다 높은 칸의 경우의 수를 모두 더하면 본인 칸에 해당하는 경우의 수를 구할 수 있습니다. 다만, 경우의 수를 구하는 순서가 달라지면 결과가 다르게 나올 수 있는데, 예를 들어 아래와 같은 예시의 경우, (1, 1)의 경우의 수를 계산하기 전에 (1, 0)의 경우의 수를 먼저 계산하면 (1, 1)의 경우의 수를 반영하지 못해 틀린 결과값을 내는 것을 확인할 수 있습니다.

```
32 30
20 25
10 100
10 0
```

```
// 옳게 구한 경우의 수
1 1
2 1
2 0
2 2
```

```
// 틀린 경우의 수
1 1
1 1
1 0
1 1
```

따라서, 저는 탐색 순서가 옳도록 보장하고자 위상 정렬을 사용했습니다
위상 정렬을 사용함으로써, 본인 칸에 더이상 합쳐지는 경우의 수가 없을 때에만, 본인 칸의 경우의 수를 구할 수 있도록 제한할 수 있기 때문입니다
위상 정렬을 사용할 수 있는 근거는, 이 문제에서 주어진 높이 정보 값을 DAG로 표현할 수 있기 때문입니다. 높은 곳으로부터 낮은 곳으로의 방향이 정해져 있고(directed), 높은곳 -> 낮은곳 -> 높은곳으로의 이동이 불가능하기 때문에 즉 이전 방문 노드로 돌아갈 수 없기 때문에 사이클이 만들어질 수 없으며(acyclic) 각각의 칸을 그래프의 vertex로, 그리고 높은 칸에서 낮은 칸으로의 이동을 그래프의 edge로 표현 가능하므로 이 문제의 높이 정보 값은 DAG입니다.
문제에서 주어진 최대 vertex 개수가 500 * 500 = 25만 개이므로, 이 모든 vertex를 살펴보는 데에 시간적으로도 문제 없습니다.

이 풀이의 가장 중요한 파트를 살펴보자면, 

```java
memo[next.row][next.col] += memo[curr.row][curr.col];
```

위상 정렬으로 탐색 중, 다음에 방문 가능한 칸(본인 칸보다 낮은 높이를 가진 칸)에 본인 칸의 경우의 수를 더해주는 부분인데
위상 정렬을 활용해 순서를 강제하는 아이디어 + 주변 경우의 수로부터 자신의 경우의 수를 구하는 아이디어가 이 풀이의 핵심이라고 생각합니다.

### 다른 풀이들

저는 위상정렬로 풀이했지만, 아래와 같은 풀이들도 가능할 것이라고 생각합니다.
순서를 강제하여 중복이 없도록 하는 방법이 여러 가지 있을 것이기 때문입니다.

#### 1. DP

아래와 같은 top-down 방식의 DP를 활용
도중에 갈림길이 나오더라도, 갈림길이 합쳐지는 좌표 p1, p2에서부터 f(p1, p2)로 재귀적으로 풀면 되기 때문에 초기 칸 -> 목적지 칸으로의 경로가 없지 않는 한 초기칸 (0,0)에 도달이 가능

```python
def f(y, x):
    """
    (y, x) 칸에 해당하는 경우의 수를 재귀적으로 반환
    """

    if (사방의 칸보다 자신의 칸이 높아 이동이 불가할 경우):
        if (y == 0 and x == 0):
            return 1
        return 0

    # 왼쪽 칸, 위쪽 칸, 오른쪽 칸, 아래쪽 칸 = f(y, x-1), f(y-1, x), f(y, x+1), f(y+1, x)
    # 이들 중 범위를 넘어서거나 자신 칸보다 높이가 낮은 칸은 무시
    # 이때, 가능한 경우 메모이제이션 활용
    return memo[y][x] = 왼쪽칸 + 위쪽칸 + 오른쪽칸 + 아래쪽칸


f(최대 세로 길이 - 1, 최대 가로 길이 - 1)
```


#### 2. BFS + priority queue

BFS의 priority queue 정렬 기준을 시작점으로부터의 거리의 오름차순이 아닌, 높이 값의 내림차순으로 설정하여 탐색
본인 칸을 처리할 때, 처리되지 못한 본인 칸보다 높은 값을 가진 칸이 없음이 보장되므로 서두의 예시와 같은 경우가 발생하지 않음

---

위 풀이들은 검증된 풀이 방법은 아니지만, 될 것 같다고 생각하는 아이디어이기에 공유드립니다
이외에도 여러 가지 풀이가 나올 수 있을 것 같으니 여러분들의 풀이를 기대하겠읍니다
