### PR TITLE
BOJ17387

### DIFF
--- a/yechan2468/BOJ17387.java
+++ b/yechan2468/BOJ17387.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ17387 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+        int x1 = Integer.parseInt(tokenizer.nextToken());
+        int y1 = Integer.parseInt(tokenizer.nextToken());
+        int x2 = Integer.parseInt(tokenizer.nextToken());
+        int y2 = Integer.parseInt(tokenizer.nextToken());
+        tokenizer = new StringTokenizer(reader.readLine());
+        int x3 = Integer.parseInt(tokenizer.nextToken());
+        int y3 = Integer.parseInt(tokenizer.nextToken());
+        int x4 = Integer.parseInt(tokenizer.nextToken());
+        int y4 = Integer.parseInt(tokenizer.nextToken());
+
+        int ccw1 = crossProduct(x1, y1, x2, y2, x3, y3);
+        int ccw2 = crossProduct(x1, y1, x2, y2, x4, y4);
+        int ccw3 = crossProduct(x3, y3, x4, y4, x1, y1);
+        int ccw4 = crossProduct(x3, y3, x4, y4, x2, y2);
+
+        if (ccw1 == 0 && ccw2 == 0) {
+            boolean isXIntersects = Math.max(Math.min(x1, x2), Math.min(x3, x4)) <= Math.min(Math.max(x1, x2), Math.max(x3, x4));
+            boolean isYIntersects = Math.max(Math.min(y1, y2), Math.min(y3, y4)) <= Math.min(Math.max(y1, y2), Math.max(y3, y4));
+
+            System.out.println(isXIntersects && isYIntersects ? "1" : "0");
+        } else {
+            System.out.println(ccw1 * ccw2 <= 0 && ccw3 * ccw4 <= 0 ? "1" : "0");
+        }
+    }
+
+    private static int crossProduct(int x1, int y1, int x2, int y2, int x3, int y3) {
+        long result = (long) (x2 - x1) * (y3 - y1) - (long) (y2 - y1) * (x3 - x1);
+        if (result < 0) return -1;
+        if (result > 0) return 1;
+        return 0;
+    }
+}


### PR DESCRIPTION
## 백준 17387 선분 교차

난이도: 골드 2
소요 시간: 2시간

카테고리: 기하

처음에 두 선분을 1차함수꼴로 만들어서 해당 점이 함수 그래프보다 위에 있는지, 아래에 있는지 판단하여 풀려고 했지만, 

1. 부동소수점 정밀도 문제
2. 선분이 y축과 평행할 때의 문제 (기울기 = Infinity)
 
때문에 골머리를 앓다가 싹 갈아엎고, CCW 알고리즘이라고 하는 알고리즘을 참고해 풀었습니다.
CCW 알고리즘에서는 두 벡터 $\vec {AB}$, $\vec {AC}$의 외적을 통해 선분 AB와 점 C와의 관계를 판별합니다.