### PR TITLE
BOJ16934

### DIFF
--- a/yechan2468/BOJ16934.java
+++ b/yechan2468/BOJ16934.java
@@ -1,0 +1,75 @@
+import java.io.*;
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class BOJ16934 {
+    private static BufferedReader reader;
+    private static BufferedWriter writer;
+    private static int n;
+    private static HashMap<String, Integer> numberedNicknames;
+    private static HashMap<Integer, HashMap<Character, HashSet<String>>> aliases, nicknames;
+
+    public static void main(String[] args) throws IOException {
+        initialize();
+
+        for (int i = 0; i < n; i++) {
+            String nickname = reader.readLine();
+
+            if (nicknames.get(nickname.length()).get(nickname.charAt(0)).contains(nickname)) {
+                numberNickname(nickname);
+                continue;
+            }
+            nicknames.get(nickname.length()).get(nickname.charAt(0)).add(nickname);
+
+            writer.write(getPossibleAlias(nickname) + "\n");
+
+            registerPrefixes(nickname);
+        }
+
+        writer.flush();
+    }
+
+    private static void numberNickname(String nickname) throws IOException {
+        numberedNicknames.putIfAbsent(nickname, 1);
+        int number = numberedNicknames.get(nickname) + 1;
+        numberedNicknames.put(nickname, number);
+        writer.write(nickname + number + "\n");
+    }
+
+    private static StringBuilder getPossibleAlias(String nickname) {
+        StringBuilder alias = new StringBuilder();
+        for (int j = 0; j < nickname.length(); j++) {
+            alias.append(nickname.charAt(j));
+            String aliasString = alias.toString();
+            if (!aliases.get(aliasString.length()).get(aliasString.charAt(0)).contains(aliasString)) break;
+        }
+        return alias;
+    }
+
+    private static void registerPrefixes(String nickname) {
+        StringBuilder alias;
+        alias = new StringBuilder();
+        for (int j = 0; j < nickname.length(); j++) {
+            alias.append(nickname.charAt(j));
+            String aliasString = alias.toString();
+            aliases.get(aliasString.length()).get(aliasString.charAt(0)).add(aliasString);
+        }
+    }
+
+    private static void initialize() throws IOException {
+        reader = new BufferedReader(new InputStreamReader(System.in));
+        writer = new BufferedWriter(new OutputStreamWriter(System.out));
+        n = Integer.parseInt(reader.readLine());
+        aliases = new HashMap<>();
+        nicknames = new HashMap<>();
+        for (int i = 0; i <= 10; i++) {
+            aliases.put(i, new HashMap<>());
+            nicknames.put(i, new HashMap<>());
+            for (char j = 'a'; j <= 'z'; j++) {
+                aliases.get(i).put(j, new HashSet<>());
+                nicknames.get(i).put(j, new HashSet<>());
+            }
+        }
+        numberedNicknames = new HashMap<>();
+    }
+}


### PR DESCRIPTION
## 백준 16934

난이도: 골드 3
소요 시간: 1시간 55분

trie가 아닌 HashMap과 HashSet을 이용해 풀었고, 핵심 로직은 아래와 같습니다

- 닉네임이 중복되는 경우 그 뒤에 incrementing 번호를 붙인다
- 가능한(다른 모든 닉네임의 접두사에 해당하지 않는) 현재 닉네임의 별칭을 찾는다
- 현재 닉네임의 접두사들을 등록한다

이때, 현재까지 등장한 닉네임의 접두사들을 `aliases`라는 이름의 자료구조에 등록했고, 이는 가능한 별칭을 찾을 때 탐색됩니다.


### troubleshooting

정답을 출력하는 코드는 30분만에 다 짰지만, 애매하게 80% 후반대에서 시간초과가 나길래
1시간 30분 정도를 찔끔찔끔 최적화하고 재채점하고를 반복하다가 시간을 낭비하게 되었습니다.

시간 초과가 발생하는 이유에는 코드의 `aliases`가 주를 이룬다고 생각해 이것들을 잘게 나누는 데에 시간을 들였는데,
문제의 원인은 numberedNickname에 있었습니다.
nickname이 같은 경우는 많지 않기 때문에 해시 충돌이 일어나더라도 영향이 적을 것이라고 제멋대로 생각을 해버렸고, 그곳에 공을 들이지 않았습니다.
하지만 '모든 10만 개의 닉네임이 동일한 경우'에는 충분히 해시 충돌로 성능 저하가 발생할 수 있었고, 아마도 87~88% 대의 테스트케이스는 아마도 그 경우였을 것 같다는 생각이 듭니다.