### PR TITLE
.gitignore 비주얼스튜디오 관련파일 설정

### DIFF
--- a/hjuohj1022/.gitignore
+++ b/hjuohj1022/.gitignore
@@ -1,0 +1,18 @@
+# Visual Studio 관련 불필요한 파일 무시
+.vs/
+*.sln
+*.vcxproj
+*.vcxproj.filters
+*.vcxproj.user
+*.suo
+*.user
+*.pdb
+*.obj
+*.exe
+*.ilk
+*.log
+*.tlog
+*.idb
+/x64/
+/Debug/
+/Release/


### PR DESCRIPTION
비주얼스튜디오 관련파일 git에 올리지 않는 gitignore설정입니다.