### PR TITLE
BOJ12850

### DIFF
--- a/yechan2468/BOJ12850.java
+++ b/yechan2468/BOJ12850.java
@@ -1,0 +1,55 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ12850 {
+    private static final int MOD = 1_000_000_007;
+    private static final long[][] ADJ = new long[][] {
+            {0, 1, 1, 0, 0, 0, 0, 0},
+            {1, 0, 1, 1, 0, 0, 0, 0},
+            {1, 1, 0, 1, 1, 0, 0, 0},
+            {0, 1, 1, 0, 1, 1, 0, 0},
+            {0, 0, 1, 1, 0, 1, 1, 0},
+            {0, 0, 0, 1, 1, 0, 0, 1},
+            {0, 0, 0, 0, 1, 0, 0, 1},
+            {0, 0, 0, 0, 0, 1, 1, 0}
+    };
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(reader.readLine());
+        long[][] powered = power(ADJ, n);
+        System.out.println(powered[0][0]);
+    }
+
+    private static long[][] power(long[][] base, int exp) {
+        long[][] result = new long[8][8];
+        for (int i = 0; i < 8; i++) {
+            result[i][i] = 1;
+        }
+
+        while (exp > 0) {
+            if (exp % 2 == 1) {
+                result = multiply(result, base);
+            }
+            base = multiply(base, base);
+            exp /= 2;
+        }
+
+        return result;
+    }
+
+    private static long[][] multiply(long[][] mat1, long[][] mat2) {
+        long[][] result = new long[8][8];
+        for (int i = 0; i < 8; i++) {
+            for (int j = 0; j < 8; j++) {
+                for (int k = 0; k < 8; k++) {
+                    result[i][j] += mat1[i][k] * mat2[k][j];
+                    result[i][j] %= MOD;
+                }
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## 백준 12850 본대 산책 2

난이도: 플래 5
풀이: 수학 (행렬)
소요 시간: 1시간 7분
Gemini의 도움을 받음

원래 생각했던 풀이는 아래와 같은 DP 풀이였습니다

```java
import java.io.BufferedReader;
import java.io.IOException;
import java.io.InputStreamReader;

public class BOJ12850 {
    private static final int NUM_NODE = 8;
    private static final int[][] ADJ = {
            {1, 2},
            {0, 2, 3},
            {0, 1, 3, 4},
            {1, 2, 4, 5},
            {2, 3, 5, 6},
            {3, 4, 7},
            {4, 7},
            {5, 6}
    };
    private static final int MOD = 1_000_000_007;

    public static void main(String[] args) throws IOException {
        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
        int n = Integer.parseInt(reader.readLine());
        int[][] memo = new int[n + 1][NUM_NODE];
        memo[0][0] = 1;

        for (int i = 0; i < n; i++) {
            for (int j = 0; j < NUM_NODE; j++) {
                for (int prev : ADJ[j]) {
                    memo[i+1][j] += memo[i][prev];
                    memo[i+1][j] %= MOD;
                }
            }
        }

        int answer = memo[n][0] % MOD;

        System.out.println(answer);
    }
}
```

하지만 N의 최댓값이 $10^9$이므로 `edge의 갯수` 12 * `N` $10^9$을 계산하려면 시간 초과가 발생합니다.
O(N) 풀이로도 해결이 안되어 Gemini의 도움을 받아 문제를 해결했습니다
변경한 풀이의 핵심은, 위 DP 풀이에서의 연산을 행렬 연산으로 나타낼 수 있다는 점입니다
초기(D=0)의 경우의 수를 나타내는 벡터를 $v_0$이라고 하면, 
```math
\vec{v_0} = \begin{bmatrix} 1 \\\ 0 \\\ 0\\\ 0\\\ 0\\\ 0\\\ 0\\\ 0 \end{bmatrix}
```
입니다.
DP 풀이에서는 이를 다음(D=1)의 경우의 수를 나타내는 벡터로 바꾸기 위해 그래프의 정보를 활용했는데, 이는 그래프의 인접 행렬 (이 행렬을 $M$이라고 하자)을 곱한 것과 같습니다.

```math
M = \begin{bmatrix} 
0&1&1&0&0&0&0&0 \\\ 
1&0&1&1&0&0&0&0 \\\ 
1&1&0&1&1&0&0&0 \\\ 
0&1&1&0&1&1&0&0 \\\ 
0&0&1&1&0&1&1&0 \\\ 
0&0&0&1&1&0&0&1 \\\ 
0&0&0&0&1&0&0&1 \\\ 
0&0&0&0&0&1&1&0 
\end{bmatrix}
```

```math
\vec{v_1} 
= M\vec{v_0} 
= 
\begin{bmatrix} 
0&1&1&0&0&0&0&0 \\\ 
1&0&1&1&0&0&0&0 \\\ 
1&1&0&1&1&0&0&0 \\\ 
0&1&1&0&1&1&0&0 \\\ 
0&0&1&1&0&1&1&0 \\\ 
0&0&0&1&1&0&0&1 \\\ 
0&0&0&0&1&0&0&1 \\\ 
0&0&0&0&0&1&1&0 
\end{bmatrix} 
\begin{bmatrix} 1 \\\ 0 \\\ 0\\\ 0\\\ 0\\\ 0\\\ 0\\\ 0 \end{bmatrix} 
= 
\begin{bmatrix} 0 \\\ 1 \\\ 1\\\ 0\\\ 0\\\ 0\\\ 0\\\ 0 \end{bmatrix} 
```

이해를 위해 한 번 더 곱해보면

```math
\vec{v_2} 
= M\vec{v_1} 
= 
\begin{bmatrix} 
0&1&1&0&0&0&0&0 \\\ 
1&0&1&1&0&0&0&0 \\\ 
1&1&0&1&1&0&0&0 \\\ 
0&1&1&0&1&1&0&0 \\\ 
0&0&1&1&0&1&1&0 \\\ 
0&0&0&1&1&0&0&1 \\\ 
0&0&0&0&1&0&0&1 \\\ 
0&0&0&0&0&1&1&0 
\end{bmatrix} 
\begin{bmatrix} 0 \\\ 1 \\\ 1\\\ 0\\\ 0\\\ 0\\\ 0\\\ 0 \end{bmatrix} 
= 
\begin{bmatrix} 2 \\\ 1 \\\ 1\\\ 2\\\ 1\\\ 0\\\ 0\\\ 0 \end{bmatrix} 
```

이와 같이 $\vec{v_{i+1}} = M \vec{v_{i}}$ 꼴로 나타냈을 때 $\vec{v_i}$는 DP 풀이에서의 memoization 배열 중 i번째와 동일하게 됨을 볼 수 있습니다. 이는 행렬 계산 과정과 DP 풀이의 덧셈 과정이 결과적으로는 동일하기 때문입니다.

이러한 사실을 이용해 마지막 (D=n) 경우의 수 배열 $\vec{v_n}$을 구하려면,

```math
\vec{v_n} = M^n \vec{v_0}
```

와 같이 인접 행렬을 거듭제곱하면 됩니다. 여기에서 행렬의 거듭제곱 $M^2 = M \times M, M^4 = M^2 \times M^2, ...$으로 나타낼 수 있으므로, 어떠한 큰 n에 대해 $M^N = M^K \times M^{2^P}$의 꼴로 나타내 큰 n에 대해서도 더 적은 시간을 사용하도록 최적화할 수 있습니다. 예를 들어, n = 35라고 하면, $M^40 = M^3 \times M^{2^5}$으로 3+5 = 8번의 행렬 곱 연산으로 $\vec{v_n}$을 구할 수 있습니다.

이렇게 구해진 $\vec{v_n}$은 0번째 공간에서 n분의 이동 후 0, 1, 2, 3, ... 번째 공간으로 갈 수 있는 경우의 수를 나타내는데, 이 문제에서 구하는 것은 n분의 이동 후 0번째 공간으로 다시 돌아오는 경우의 수를 구하는 것이므로 $\vec{v_n}$의 0번째 숫자를 출력하면 됩니다.
