### PR TITLE
BOJ1799

### DIFF
--- a/yechan2468/BOJ1799.java
+++ b/yechan2468/BOJ1799.java
@@ -1,0 +1,99 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BOJ1799 {
+    static int n, numCells;
+    static List<Cell> blackCells, whiteCells;
+    static boolean[] occupied1, occupied2;
+    static int blackMax, whiteMax;
+
+    public static void main(String[] args) throws IOException {
+        initialize();
+
+        dfs(blackCells, 0, 0, true);
+        dfs(whiteCells, 0, 0, false);
+
+        System.out.println(blackMax + whiteMax);
+    }
+
+    private static void dfs(List<Cell> cells, int index, int count, boolean isBlack) {
+        if (!isPromising(cells, index, count, isBlack)) return;
+        if (index == cells.size()) {
+            if (isBlack) {
+                blackMax = Math.max(blackMax, count);
+            } else {
+                whiteMax = Math.max(whiteMax, count);
+            }
+            return;
+        }
+
+        Cell cell = cells.get(index);
+        int row = cell.row;
+        int col = cell.col;
+
+        if (isValid(row, col)) {
+            occupy(row, col);
+            dfs(cells, index + 1, count + 1, isBlack);
+            deoccupy(row, col);
+        }
+
+        dfs(cells, index + 1, count, isBlack);
+    }
+
+    private static void occupy(int row, int column) {
+        occupied1[row + column] = true;
+        occupied2[row - column + n] = true;
+    }
+
+    private static void deoccupy(int row, int column) {
+        occupied1[row + column] = false;
+        occupied2[row - column + n] = false;
+    }
+
+    private static boolean isValid(int row, int column) {
+        return !occupied1[row + column] && !occupied2[row - column + n];
+    }
+
+    private static boolean isPromising(List<Cell> cells, int index, int count, boolean isBlack) {
+        return count + (cells.size() - index) > (isBlack ? blackMax : whiteMax);
+    }
+
+    private static void initialize() throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(reader.readLine());
+        blackCells = new ArrayList<>();
+        whiteCells = new ArrayList<>();
+        numCells = 0;
+        for (int i = 0; i < n; i++) {
+            StringTokenizer tokenizer = new StringTokenizer(reader.readLine());
+            for (int j = 0; j < n; j++) {
+                String s = tokenizer.nextToken();
+                if (s.equals("1")) {
+                    if ((i + j) % 2 == 0) {
+                        whiteCells.add(new Cell(i, j));
+                    } else {
+                        blackCells.add(new Cell(i, j));
+                    }
+                    numCells++;
+                }
+            }
+        }
+        occupied1 = new boolean[20];
+        occupied2 = new boolean[20];
+        blackMax = 0;
+        whiteMax = 0;
+    }
+
+    private static class Cell {
+        int row, col;
+
+        public Cell(int row, int col) {
+            this.row = row;
+            this.col = col;
+        }
+    }
+}


### PR DESCRIPTION
## 백준 1799 비숍

[https://www.acmicpc.net/problem/1799](https://www.acmicpc.net/problem/1799)

난이도: 플래 5
소요 시간: 1시간 30분
풀이: 백트래킹

백트래킹으로 풀었습니다. 
10초의 긴 시간이 주어져 있음에도 불구하고, 시간초과가 계속 발생했는데, 그 이유는
체스판의 최대 크기가 10이므로 $O(2^n)$의 알고리즘으로는 최대 $2^{100}$번이라는 아주 많은 연산을 해야 하기 때문입니다.
이 알고리즘이 시간 초과가 나지 않게 하도록 하는 가장 핵심 아이디어는, '흑 칸에 있는 비숍은 백 칸에 있는 비숍을 공격하지 못한다'입니다. (그 반대도 성립)
따라서 100칸의 체스 칸에 대해 최대 $2^{100}$의 연산을 하도록 하는 대신, 
흑 50칸의 체스 칸에 대해 최대 $2^{50}$의 연산과 백 50칸의 체스 칸에 대해 최대 $2^{50}$의 연산을 하도록 함으로써 ($2 * 2^{50} = 2^{51}$)
아주 많은 연산을 줄일 수 있습니다.